### PR TITLE
fix: replace deprecated np.trapz with np.trapezoid

### DIFF
--- a/pyowt/OpticalVariables.py
+++ b/pyowt/OpticalVariables.py
@@ -197,7 +197,7 @@ class OpticalVariables():
     def calculate_Area(self):
         bands_for_Area = np.array(self.sensor_RGB_bands)
         Rrs_for_Area = self.Rrs[:, :, np.where(np.isin(self.band, bands_for_Area))[0]]
-        self.Area = np.trapz(x=bands_for_Area, y=Rrs_for_Area, axis=-1)
+        self.Area = np.trapezoid(x=bands_for_Area, y=Rrs_for_Area, axis=-1)
 
 
     def calculate_NDI(self):


### PR DESCRIPTION
Closes #12

`np.trapz` was deprecated in NumPy 2.0 and removed in NumPy 2.1. Replaced with `np.trapezoid` which has identical behavior.

### Change
- `pyowt/OpticalVariables.py:200`: `np.trapz` → `np.trapezoid`